### PR TITLE
fix: Pass filtered $nodeContextPaths on to publishAction()

### DIFF
--- a/Classes/Aspect/WorkspaceControllerPublishAspect.php
+++ b/Classes/Aspect/WorkspaceControllerPublishAspect.php
@@ -81,6 +81,7 @@ class WorkspaceControllerPublishAspect
         assert($controller instanceof BackendServiceController);
 
         $nodeContextPaths = $this->filterExistingContextPaths($joinPoint->getMethodArgument('nodeContextPaths'));
+        $joinPoint->setMethodArgument('nodeContextPaths', $nodeContextPaths);
         if (count($nodeContextPaths) === 0) {
             $success = new Success();
             $success->setMessage('No nodes to publish');

--- a/Classes/Aspect/WorkspaceControllerPublishAspect.php
+++ b/Classes/Aspect/WorkspaceControllerPublishAspect.php
@@ -12,9 +12,7 @@ use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Utility\Algorithms;
 use Neos\Neos\Ui\ContentRepository\Service\NodeService;
 use Neos\Neos\Ui\Controller\BackendServiceController;
-use Neos\Neos\Ui\Domain\Model\Feedback\Messages\Success;
 use Neos\Neos\Ui\Domain\Model\FeedbackCollection;
-use Neos\Utility\ObjectAccess;
 use Netlogix\Neos\AsyncWorkspaceActions\Domain\Model\Job;
 use Netlogix\Neos\AsyncWorkspaceActions\Domain\Repository\JobRepository;
 use Netlogix\Neos\AsyncWorkspaceActions\Job\Workspace\Publish;
@@ -82,20 +80,9 @@ class WorkspaceControllerPublishAspect
 
         $nodeContextPaths = $this->filterExistingContextPaths($joinPoint->getMethodArgument('nodeContextPaths'));
         $joinPoint->setMethodArgument('nodeContextPaths', $nodeContextPaths);
-        if (count($nodeContextPaths) === 0) {
-            $success = new Success();
-            $success->setMessage('No nodes to publish');
-            $this->feedbackCollection->add($success);
-
-            $view = ObjectAccess::getProperty($controller, 'view', true);
-            $view->assign('value', $this->feedbackCollection);
-
-            return;
-        }
 
         $requestHandler = $this->bootstrap->getActiveRequestHandler();
-
-        if (!($requestHandler instanceof HttpRequestHandlerInterface) || count($nodeContextPaths) < $this->threshold) {
+        if (!($requestHandler instanceof HttpRequestHandlerInterface) || count($nodeContextPaths) === 0 || count($nodeContextPaths) < $this->threshold) {
             $joinPoint->getAdviceChain()->proceed($joinPoint);
             return;
         }


### PR DESCRIPTION
The proceed() call would sometimes throw an exception
because of context paths that cannot be converted to NodeInterface.
As we already filter the context paths, we may as well use
the clean list for further usage.